### PR TITLE
Fix issue #17: Tracking doubled when 45 FPS, so world isn't locked to…

### DIFF
--- a/neo/d3xp/Player.cpp
+++ b/neo/d3xp/Player.cpp
@@ -9866,7 +9866,8 @@ void idPlayer::Move()
 				idMat3 bodyAx = idAngles( bodyAng.pitch, bodyAng.yaw - commonVr->bodyYawOffset, bodyAng.roll ).Normalize180().ToMat3();
 			
 				
-				newBodyOrigin = bodyOrigin + bodyAx[0] * commonVr->poseHmdBodyPositionDelta.x + bodyAx[1] * commonVr->poseHmdBodyPositionDelta.y;
+				newBodyOrigin = bodyOrigin + bodyAx[0] * commonVr->remainingMoveHmdBodyPositionDelta.x + bodyAx[1] * commonVr->remainingMoveHmdBodyPositionDelta.y;
+				commonVr->remainingMoveHmdBodyPositionDelta.x = commonVr->remainingMoveHmdBodyPositionDelta.y = 0;
 				//newBodyOrigin.z = 0.0f;
 			
 				commonVr->motionMoveDelta = newBodyOrigin - bodyOrigin;

--- a/neo/vr/Vr.cpp
+++ b/neo/vr/Vr.cpp
@@ -1772,6 +1772,7 @@ void iVr::FrameStart( void )
 	if ( hasOculusRift )
 	{
 		HMDGetOrientation( poseHmdAngles, poseHmdHeadPositionDelta, poseHmdBodyPositionDelta, poseHmdAbsolutePosition, false );
+		remainingMoveHmdBodyPositionDelta = poseHmdBodyPositionDelta;
 		return;
 	}
 
@@ -1803,6 +1804,7 @@ void iVr::FrameStart( void )
 
 
 	HMDGetOrientation( poseHmdAngles, poseHmdHeadPositionDelta, poseHmdBodyPositionDelta, poseHmdAbsolutePosition, false );
+	remainingMoveHmdBodyPositionDelta = poseHmdBodyPositionDelta;
 	
 	for ( int i = 0; i < 2; i++ )
 	{

--- a/neo/vr/Vr.h
+++ b/neo/vr/Vr.h
@@ -329,6 +329,7 @@ public:
 	idAngles			poseHmdAngles;
 	idVec3				poseHmdHeadPositionDelta;
 	idVec3				poseHmdBodyPositionDelta;
+	idVec3				remainingMoveHmdBodyPositionDelta;
 	idVec3				poseHmdAbsolutePosition;
 
 	idVec3				poseHandPos[2];


### PR DESCRIPTION
… chaperone when I move my head

After you use a delta, you need to reset it back to zero.

Tracking is no longer doubled at 45 FPS (or any other frame rate). Fixes issue #17.