### PR TITLE
Fix issue #36: flashlight shadow in Mars City 1

### DIFF
--- a/neo/d3xp/Player.cpp
+++ b/neo/d3xp/Player.cpp
@@ -13274,7 +13274,10 @@ void idPlayer::CalculateViewFlashPos( idVec3 &origin, idMat3 &axis, idVec3 flash
 				// adjustAng += owner->GetViewBobAngles();
 				axis = adjustAng.ToMat3() * axis;
 				flashlight->GetRenderEntity()->allowSurfaceInViewID = -1;
-				flashlight->GetRenderEntity()->suppressShadowInViewID = 0;
+				// Carl: This fixes the flashlight shadow in Mars City 1.
+				// I could check if ( spectating || !weaponEnabled || gameLocal.world->spawnArgs.GetBool( "no_Weapons" ) )
+				// but I don't think an armor-mounted light should ever cast a flashlight-shaped shadow
+				flashlight->GetRenderEntity()->suppressShadowInViewID = entityNumber + 1;
 				setLeftHand = true;
 			}
 	}


### PR DESCRIPTION
I removed the flashlight shadow whenever it thinks the flashlight is mounted on the body, which includes when you don't have a flashlight at all. Fixes issue #36.