### PR TITLE
Wake up monsters by speaking (untested). Issue #26

### DIFF
--- a/neo/d3xp/Player.cpp
+++ b/neo/d3xp/Player.cpp
@@ -6894,6 +6894,10 @@ void idPlayer::UpdateWeapon()
 	
 	assert( !spectating );
 	
+	// Voice wakes up nearby monsters while you're speaking
+	if( vr_talkMode.GetInteger() > 0 && ( usercmd.buttons & BUTTON_CHATTING ) )
+		gameLocal.AlertAI( this );
+
 	if( common->IsClient() )
 	{
 		// clients need to wait till the weapon and it's world model entity


### PR DESCRIPTION
In theory, fixes issue #26.
But I can't find any monsters that you can sneak up on to test this with.

I'm not taking into account volume yet... but neither does the weapon firing code that wakes up monsters.