### PR TITLE
Added the QuakeCon style teleport. Time slows down when holding down …

### DIFF
--- a/neo/d3xp/Player.h
+++ b/neo/d3xp/Player.h
@@ -372,6 +372,9 @@ public:
 	
 	bool					noclip;
 	bool					godmode;
+	bool					warpMove;
+	idVec3					warpVel;
+	int						warpTime;
 	
 	bool					spawnAnglesSet;		// on first usercmd, we must set deltaAngles
 	idAngles				spawnAngles;
@@ -653,6 +656,9 @@ public:
 	int						AdjustDamageAmount( const int inputDamage );
 	
 	// use exitEntityNum to specify a teleport with private camera view and delayed exit
+	//virtual void			StopMove(moveStatus_t status);
+	//virtual bool			MoveToPosition(const idVec3& pos);
+
 	virtual void			Teleport( const idVec3& origin, const idAngles& angles, idEntity* destination );
 	virtual bool			TeleportPathSegment( const idVec3& start, const idVec3& end, idVec3& lastPos );
 	virtual void			TeleportPath( const idVec3& target );

--- a/neo/d3xp/menus/MenuScreen.h
+++ b/neo/d3xp/menus/MenuScreen.h
@@ -2208,6 +2208,7 @@ public:
 		enum vrSafetyProtocols_t
 		{
 			SAFETY_PROTOCOLS_FIELD_TELEPORTATION,
+			SAFETY_PROTOCOLS_FIELD_TELEPORTATION_MODE,
 			SAFETY_PROTOCOLS_FIELD_SNAP_TURNS,
 			SAFETY_PROTOCOLS_FIELD_WALK_SPEED_ADJUST,
 			SAFETY_PROTOCOLS_FIELD_MOTION_SICKNESS,
@@ -2240,6 +2241,7 @@ public:
 	private:
 		int	originalChaperone;
 		int	originalTeleport;
+		int	originalTeleportMode;
 		int	originalMotionSickness;
 		float	originalWalkSpeedAdjust;
 		float originalComfortDelta;

--- a/neo/d3xp/menus/MenuScreen_Shell_VR_Safety_Protocols.cpp
+++ b/neo/d3xp/menus/MenuScreen_Shell_VR_Safety_Protocols.cpp
@@ -76,6 +76,14 @@ void idMenuScreen_Shell_VR_Safety_Protocols::Initialize( idMenuHandler * data ) 
 	options->AddChild( control );
 
 	control = new (TAG_SWF)idMenuWidget_ControlButton();
+	control->SetOptionType(OPTION_SLIDER_TEXT);
+	control->SetLabel("Teleport Mode");
+	control->SetDataSource(&systemData, idMenuDataSource_Shell_VR_Safety_Protocols::SAFETY_PROTOCOLS_FIELD_TELEPORTATION_MODE);
+	control->SetupEvents(DEFAULT_REPEAT_TIME, options->GetChildren().Num());
+	control->AddEventAction(WIDGET_EVENT_PRESS).Set(WIDGET_ACTION_COMMAND, idMenuDataSource_Shell_VR_Safety_Protocols::SAFETY_PROTOCOLS_FIELD_TELEPORTATION_MODE);
+	options->AddChild(control);
+
+	control = new (TAG_SWF)idMenuWidget_ControlButton();
 	control->SetOptionType( OPTION_SLIDER_TEXT );
 	control->SetLabel( "Turning" );
 	control->SetDataSource( &systemData, idMenuDataSource_Shell_VR_Safety_Protocols::SAFETY_PROTOCOLS_FIELD_SNAP_TURNS );
@@ -340,6 +348,7 @@ void idMenuScreen_Shell_VR_Safety_Protocols::idMenuDataSource_Shell_VR_Safety_Pr
 	originalComfortDelta = vr_comfortDelta.GetFloat();
 	originalChaperone = vr_chaperone.GetInteger();
 	originalTeleport = vr_teleport.GetInteger();
+	originalTeleportMode = vr_teleportMode.GetInteger();
 	originalMotionSickness = vr_motionSickness.GetInteger();
 	originalWalkSpeedAdjust = vr_walkSpeedAdjust.GetFloat();
 	originalKnockBack = vr_knockBack.GetInteger();
@@ -381,6 +390,14 @@ void idMenuScreen_Shell_VR_Safety_Protocols::idMenuDataSource_Shell_VR_Safety_Pr
 			static const int numValues = 5;
 			static const int values[numValues] = { 0, 1, 2, 3, 4 };
 			vr_teleport.SetInteger( AdjustOption( vr_teleport.GetInteger(), values, numValues, adjustAmount ) );
+			break;
+		}
+
+		case SAFETY_PROTOCOLS_FIELD_TELEPORTATION_MODE:
+		{
+			static const int numValues = 2;
+			static const int values[numValues] = { 0, 1};
+			vr_teleportMode.SetInteger(AdjustOption(vr_teleportMode.GetInteger(), values, numValues, adjustAmount));
 			break;
 		}
 
@@ -530,6 +547,12 @@ idSWFScriptVar idMenuScreen_Shell_VR_Safety_Protocols::idMenuDataSource_Shell_VR
 			return names[vr_teleport.GetInteger()];
 		}
 
+		case SAFETY_PROTOCOLS_FIELD_TELEPORTATION_MODE:
+		{
+			const char* names[] = { "Blink", "QuakeCon"};
+			return names[vr_teleportMode.GetInteger()];
+		}
+
 		case SAFETY_PROTOCOLS_FIELD_SNAP_TURNS:
 		{
 			float f = vr_comfortDelta.GetFloat();
@@ -608,6 +631,10 @@ idMenuScreen_Shell_VR_Safety_Protocols::idMenuDataSource_Shell_VR_Gameplay_Optio
 bool idMenuScreen_Shell_VR_Safety_Protocols::idMenuDataSource_Shell_VR_Safety_Protocols::IsDataChanged() const {
 	
 	if ( originalTeleport != vr_teleport.GetInteger() )
+	{
+		return true;
+	}
+	if (originalTeleportMode != vr_teleportMode.GetInteger())
 	{
 		return true;
 	}

--- a/neo/vr/Vr.cpp
+++ b/neo/vr/Vr.cpp
@@ -184,6 +184,7 @@ idCVar vr_teleportHint( "vr_teleportHint", "0", CVAR_BOOL | CVAR_ARCHIVE, "" ); 
 // Koz end
 // Carl
 idCVar vr_teleport( "vr_teleport", "2", CVAR_INTEGER | CVAR_ARCHIVE, "Player can teleport at will. 0 = disabled, 1 = gun sight, 2 = right hand, 3 = left hand, 4 = head", 0, 4 );
+idCVar vr_teleportMode("vr_teleportMode", "0", CVAR_INTEGER | CVAR_ARCHIVE, "Teleport Mode. 0 = Blink, 1 = QuakeCon style", 0, 1);
 idCVar vr_teleportMaxTravel( "vr_teleportMaxTravel", "950", CVAR_INTEGER | CVAR_ARCHIVE, "Maximum teleport path length/complexity/time. About 250 or 500 are good choices, but must be >= about 950 to use tightrope in MC Underground.", 150, 5000 );
 idCVar vr_teleportThroughDoors( "vr_teleportThroughDoors", "0", CVAR_BOOL | CVAR_ARCHIVE, "Player can teleport somewhere visible even if the path to get there takes them through closed (but not locked) doors." );
 idCVar vr_motionSickness( "vr_motionSickness", "10", CVAR_INTEGER | CVAR_ARCHIVE, "Motion sickness prevention aids. 0 = None, 1 = Chaperone, 2 = Reduce FOV, 3 = Black Screen, 4 = Black & Chaperone, 5 = Reduce FOV & Chaperone, 6 = Slow Mo, 7 = Slow Mo & Chaperone, 8 = Slow Mo & Reduce FOV, 9 = Slow Mo, Chaperone, Reduce FOV, 10 = Third Person, 11 = Particles, 12 = Particles & Chaperone", 0, 12 );

--- a/neo/vr/Vr.h
+++ b/neo/vr/Vr.h
@@ -520,6 +520,7 @@ extern idCVar	vr_teleportButtonMode;
 extern idCVar	vr_teleportHint;
 
 extern idCVar	vr_teleport;
+extern idCVar	vr_teleportMode;
 extern idCVar	vr_teleportMaxTravel;
 extern idCVar	vr_teleportThroughDoors;
 extern idCVar	vr_motionSickness;


### PR DESCRIPTION
…the teleport button, and darts over to the new position, once the button is released. The teleport mechanism is described in detail at http://www.gamespot.com/articles/doom-may-have-solved-vrs-traversal-problem/1100-6442439/.

vr_teleportMode can be set in console or in the VR Options menu.
0 - Blink (default)
1 - QuakeCon style

The QuakeCon style teleport can be viewed at https://youtu.be/pKKYWieDHJM