### PR TITLE
Much better elbow inverse kinematics.

### DIFF
--- a/neo/framework/UsercmdGen.cpp
+++ b/neo/framework/UsercmdGen.cpp
@@ -1766,8 +1766,8 @@ void idUsercmdGenLocal::EvaluateVRMoveMode()
 	}
 	
 	// Koz make sure the torso faces some form of forward.
-
-	CalcTorsoYawDelta();
+	if( !ik_debug.GetBool() )
+		CalcTorsoYawDelta();
 
 	bool okToMove = false;
 	bool moveRequested = ( abs( cmd.forwardmove ) >= 0.05 || abs( cmd.rightmove ) >= 0.05 );


### PR DESCRIPTION
The elbows should follow your real elbows better, and it should look less uncomfortable now. Before, the elbows were always pointed at the floor.

When ik_debug is enabled, this also disables automatic torso yaw (so you can test the arms more easily), and it shows more debug information.

To do - fix it so the arm model doesn't look twisted.