### PR TITLE
 Automatically detect game path from Steam or GOG (Windows only)

### DIFF
--- a/Installer.nsi
+++ b/Installer.nsi
@@ -155,7 +155,22 @@ FunctionEnd
 
 Function .onInit
   !insertmacro MUI_LANGDLL_DISPLAY
-  ReadRegStr $R0 HKCU "Software\Valve\Steam" SteamPath
+  ; Check for the Good Old Games (GOG) version first, because we know it's the right drive.
+  ; This nullsoft installer is a 32bit executable (I think), so this should work.
+  ; Otherwise we might need to check Software\Wow6432Node\GOG.com\Games\1135892318
+  ReadRegStr $R0 HKCU "Software\GOG.com\Games\1135892318" "Path"
+  IfErrors lbl_checksteam 0
+  Push $R0
+  Push "/"
+  Call StrSlash
+  Pop $R0
+  StrCpy $INSTDIR $R0
+  Return
+  ; Check for the Steam version if GOG failed. This path will be wrong if it's on another drive.
+  ; Note that the retail disc version also uses Steam, so these are the only two legal ways.
+  lbl_checksteam:
+  ClearErrors
+  ReadRegStr $R0 HKCU "Software\Valve\Steam" "SteamPath"
   IfErrors lbl_error 0
   Push $R0
   Push "/"

--- a/README.txt
+++ b/README.txt
@@ -2458,27 +2458,28 @@ __________________________________________________________
 
 3. Download and install the latest CMake, saying YES to adding CMake to your path.
 
-4. Generate the VC13 projects using CMake by doubleclicking a matching configuration .bat
+4. Generate the VC projects using CMake by doubleclicking a matching configuration .bat
    file in the neo/ folder. eg. cmake-vs2013-64bit.bat (it will erase your build folder)
 
 5. (UPDATED) Go to https://developer.oculus.com/downloads/pc/1.17.0/Oculus_SDK_for_Windows/ then
    download and extract it somewhere. Copy the LibOVR folder to DOOM-3-BFG/neo/libs
 
-6. Init/Update the submodules in Git to get OpenVR. In TortoiseGit, right click in the folder
-   then choose TortoiseGit > Submodule Update... then press OK.
+6. (UPDATED) Init/Update the submodules in Git to get OpenVR. In TortoiseGit, right click in the
+   folder then choose TortoiseGit > Submodule Update... then press OK.
 
 7. Open the following file in Visual Studio and compile it:
 	DOOM-3-BFG/build/Doom3BFGVR.sln
 	
-8. Download ffmpeg-4.0-win32-shared.zip from
+8. (UPDATED) Download ffmpeg-4.0-win32-shared.zip from
 	https://ffmpeg.zeranoe.com/builds/win32/shared/
 	and/or ffmpeg-4.0-win64-shared.zip from
 	https://ffmpeg.zeranoe.com/builds/win64/shared/
 
 9. Extract the FFmpeg DLLs to your current build directory (eg. Release) under DOOM-3-BFG/build/
 
-10. In Visual Studio, right click project Doom3BFGVR, click Properties. Set Configuration to
-    All Configurations. Choose Debugging, set Command Arguments to:
+10. (OPTIONAL) If Doom 3 BFG wasn't installed from Steam or GOG, set the path in Visual Studio.
+    Right click project Doom3BFGVR, click Properties. Set Configuration to All Configurations.
+    Choose Debugging, set Command Arguments to:
     +set fs_basepath "C:\Program Files (x86)\Steam\steamapps\common\DOOM 3 BFG Edition"
     or wherever you installed Doom 3 BFG edition
 


### PR DESCRIPTION
The EXE (with DLLs) can now be placed anywhere and it will (probably) work. This is most useful when debugging from Visual Studio. The mod's "Fully Possessed" folder still needs to be in the game's folder though.

Partly based on GZDoom code by Randy Heit, Gaerzi, and Mike Swanson. But I made large improvements.
It can detect the Steam path even when not on the default Steam drive.